### PR TITLE
Release for 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.0.3](https://github.com/udus122/dataview-publisher/compare/0.0.2...0.0.3) - 2024-06-10
+- Feature/insert-template-command by @udus122 in https://github.com/udus122/dataview-publisher/pull/3
+
 ## [0.0.2](https://github.com/udus122/dataview-publisher/compare/0.0.1...0.0.2) - 2024-06-10
 
 ## [0.0.1](https://github.com/udus122/dataview-publisher/commits/0.0.1) - 2024-06-10

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "dataview-publisher",
   "name": "Dataview Publisher",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "minAppVersion": "1.6.3",
   "description": "Serialize Dataview query for Obsidian Publish",
   "author": "UD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataview-publisher",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Serialize Dataview query for Obsidian Publish",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This pull request is for the next release as 0.0.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.0.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Feature/insert-template-command by @udus122 in https://github.com/udus122/dataview-publisher/pull/3


**Full Changelog**: https://github.com/udus122/dataview-publisher/compare/0.0.2...0.0.3