### PR TITLE
Release for 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.1.2](https://github.com/udus122/dataview-publisher/compare/0.1.1...0.1.2) - 2024-06-10
+
 ## [0.1.1](https://github.com/udus122/dataview-publisher/compare/0.1.0...0.1.1) - 2024-06-10
 
 ## [0.1.0](https://github.com/udus122/dataview-publisher/compare/0.0.3...0.1.0) - 2024-06-10

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "dataview-publisher",
   "name": "Dataview Publisher",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "minAppVersion": "1.6.3",
   "description": "Output markdown from your Dataview queries and keep them up to date. You can also be able to publish them.",
   "author": "UD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataview-publisher",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Output markdown from your Dataview queries and keep them up to date. You can also be able to publish them.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This pull request is for the next release as 0.1.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/udus122/dataview-publisher/compare/0.1.1...0.1.2