### PR TITLE
Fix "To get the active editor ..."

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,9 +29,11 @@ export default class Main extends Plugin {
       saveCommandDefinition.callback = () => {
         this.originalSaveCallback();
 
-        if (this.settings.updateOnSave) {
+        const editor = this.app.workspace.activeEditor?.editor;
+
+        if (this.settings.updateOnSave && editor) {
           const operator = new Operator(this.app as UnsafeApp);
-          operator.updateActiveFile();
+          operator.updateActiveFile(editor);
         }
       };
     }

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,4 +1,4 @@
-import { Editor, MarkdownView, type TFile } from "obsidian";
+import { type Editor, type TFile } from "obsidian";
 import { Replacer, UnsafeApp } from "./types";
 import { createReplacerFromContent } from "./dataview-publisher";
 import { DataviewApi } from "obsidian-dataview";
@@ -13,8 +13,7 @@ export class Operator {
     this.dv = getDataviewAPI(app);
   }
 
-  async updateActiveFile() {
-    const editor = this.getEditor();
+  async updateActiveFile(editor: Editor) {
     const cursor = editor.getCursor();
     const content = editor.getValue();
 
@@ -23,14 +22,6 @@ export class Operator {
 
     editor.setValue(updatedContent);
     editor.setCursor(cursor);
-  }
-
-  private getEditor(): Editor {
-    const activeLeaf = this.app.workspace.getActiveViewOfType(MarkdownView);
-    if (!activeLeaf) {
-      throw new Error("No active leaf found");
-    }
-    return activeLeaf.editor;
   }
 
   updateFromSource(source: string) {


### PR DESCRIPTION
> [const activeLeaf = this.app.workspace.getActiveViewOfType(MarkdownView);](https://github.com/udus122/dataview-publisher/blob/125dbf89cac67a1ce93c3627551075268095d2b7/src/operations.ts#L29-L33)
To get the active editor use this.app.workspace.activeEditor?.editor, which will mean that this code works in Canvas.

https://github.com/obsidianmd/obsidian-releases/pull/3674#issuecomment-2163476152

- use `app.workspace.activeEditor` instead of `app.workspace.getActiveViewOfType(MarkdownView)`
	- At the same time, change the editor to be passed as an argument to the method.
	- To prevent plugins from running when a note is not open