### PR TITLE
Fix "This should also be shown to the user, not everyone knows of the dev console."

### DIFF
--- a/src/dataview-utils.ts
+++ b/src/dataview-utils.ts
@@ -10,11 +10,3 @@ export function getDataviewAPI(app?: UnsafeApp | undefined): DataviewApi {
 
   return api;
 }
-
-export async function executeQueryMarkdown(
-  query: string,
-  app?: UnsafeApp | undefined
-): Promise<string> {
-  const dv = getDataviewAPI(app);
-  return await dv.tryQueryMarkdown(query);
-}

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,4 +1,4 @@
-import { type Editor, type TFile } from "obsidian";
+import { Notice, type Editor, type TFile } from "obsidian";
 import { Replacer, UnsafeApp } from "./types";
 import { createReplacerFromContent } from "./dataview-publisher";
 import { DataviewApi } from "obsidian-dataview";
@@ -10,7 +10,11 @@ export class Operator {
 
   constructor(app: UnsafeApp) {
     this.app = app;
-    this.dv = getDataviewAPI(app);
+    try {
+      this.dv = getDataviewAPI(app);
+    } catch (e) {
+      new Notice(e.message);
+    }
   }
 
   async updateActiveFile(editor: Editor) {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -21,7 +21,7 @@ export class Operator {
     const cursor = editor.getCursor();
     const content = editor.getValue();
 
-    const replacer = await createReplacerFromContent(content);
+    const replacer = await createReplacerFromContent(content, this.dv);
     const updatedContent = this.updateContnet(content, replacer);
 
     editor.setValue(updatedContent);
@@ -56,7 +56,7 @@ export class Operator {
   private async updateDataviewPublisherOutput(tfile: TFile) {
     const content = await this.app.vault.cachedRead(tfile);
 
-    const replacer = await createReplacerFromContent(content);
+    const replacer = await createReplacerFromContent(content, this.dv);
     const updatedContent = this.updateContnet(content, replacer);
 
     this.app.vault.process(tfile, () => updatedContent);


### PR DESCRIPTION
> [throw new Error("Dataview API not found");](https://github.com/udus122/dataview-publisher/blob/125dbf89cac67a1ce93c3627551075268095d2b7/src/dataview-utils.ts#L8-L9)
This should also be shown to the user, not everyone knows of the dev console.

https://github.com/obsidianmd/obsidian-releases/pull/3674#issuecomment-2163476152

- Notify if DataviewAPI fails to load
- Changed to reuse the Dataview API loaded at the time of Operator initialization.