### PR TITLE
Fix "Don't prefix the command id with the plugin id ..."

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,7 +7,7 @@ import { Operator } from "./operations";
 export function createCommands(app: UnsafeApp, settings: Settings): Command[] {
   return [
     {
-      id: "dataview-publisher-insert-block",
+      id: "insert-block",
       name: "Insert dataview publish block",
       editorCallback: (editor) => {
         const { line, ch } = editor.getCursor();
@@ -33,7 +33,7 @@ export function createCommands(app: UnsafeApp, settings: Settings): Command[] {
       },
     },
     {
-      id: "dataview-publisher-update-blocks",
+      id: "update-blocks",
       name: "Update dataview publish blocks",
       callback: () => {
         const operator = new Operator(app);
@@ -41,7 +41,7 @@ export function createCommands(app: UnsafeApp, settings: Settings): Command[] {
       },
     },
     {
-      id: "dataview-publisher-update-blocks-and-publish",
+      id: "update-blocks-and-publish",
       name: "Update dataview publish blocks and open publish panel",
       callback: () => {
         const operator = new Operator(app);


### PR DESCRIPTION
> [id: "dataview-publisher-insert-block",](https://github.com/udus122/dataview-publisher/blob/125dbf89cac67a1ce93c3627551075268095d2b7/src/commands.ts#L10), [id: "dataview-publisher-update-blocks",](https://github.com/udus122/dataview-publisher/blob/125dbf89cac67a1ce93c3627551075268095d2b7/src/commands.ts#L36), [id: "dataview-publisher-update-blocks-and-publish",](https://github.com/udus122/dataview-publisher/blob/125dbf89cac67a1ce93c3627551075268095d2b7/src/commands.ts#L44)
Don't prefix the command id with the plugin id, Obsidian will make sure that there are no conflicts with other plugins.
Also the command names could be shorter.

https://github.com/obsidianmd/obsidian-releases/pull/3674#issuecomment-2163476152