### PR TITLE
Release for 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.3.2](https://github.com/udus122/dataview-publisher/compare/0.3.1...0.3.2) - 2024-06-16
+- Fix/output-newline by @udus122 in https://github.com/udus122/dataview-publisher/pull/29
+
 ## [0.3.1](https://github.com/udus122/dataview-publisher/compare/0.3.0...0.3.1) - 2024-06-16
 - update README by @udus122 in https://github.com/udus122/dataview-publisher/pull/25
 - Update screenshots by @udus122 in https://github.com/udus122/dataview-publisher/pull/27

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "dataview-publisher",
   "name": "Dataview Publisher",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "minAppVersion": "1.6.3",
   "description": "Output markdown from your Dataview queries and keep them up to date. You can also publish them.",
   "author": "UD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataview-publisher",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Output markdown from your Dataview queries and keep them up to date. You can also publish them.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This pull request is for the next release as 0.3.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.3.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.3.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix/output-newline by @udus122 in https://github.com/udus122/dataview-publisher/pull/29


**Full Changelog**: https://github.com/udus122/dataview-publisher/compare/0.3.1...0.3.2