### PR TITLE
Release for 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.3.7](https://github.com/udus122/dataview-publisher/compare/0.3.6...0.3.7) - 2024-06-21
+- fix: allow space by @udus122 in https://github.com/udus122/dataview-publisher/pull/39
+
 ## [0.3.6](https://github.com/udus122/dataview-publisher/compare/0.3.5...0.3.6) - 2024-06-20
 - Feature/notice-error by @udus122 in https://github.com/udus122/dataview-publisher/pull/37
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "dataview-publisher",
   "name": "Dataview Publisher",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "minAppVersion": "1.6.3",
   "description": "Output markdown from your Dataview queries and keep them up to date. You can also publish them.",
   "author": "UD",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataview-publisher",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataview-publisher",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataview-publisher",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Output markdown from your Dataview queries and keep them up to date. You can also publish them.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This pull request is for the next release as 0.3.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.3.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.3.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: allow space by @udus122 in https://github.com/udus122/dataview-publisher/pull/39


**Full Changelog**: https://github.com/udus122/dataview-publisher/compare/0.3.6...0.3.7